### PR TITLE
const ではなくimport

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+// constではなくimport 
 const { readFile } = require('fs/promises');
 const { dirname, join } = require('path');
 


### PR DESCRIPTION
Babelは古いフレームワーク
作成した後にわかったので修正が必要